### PR TITLE
Return the WebSocket sub-protocol when accepting the connection

### DIFF
--- a/backend/api/consumers.py
+++ b/backend/api/consumers.py
@@ -23,7 +23,7 @@ class RetrospectiveConsumer(WebsocketConsumer):
 
         async_to_sync(self.channel_layer.group_add)(self.retro_id, self.channel_name)
 
-        self.accept()
+        self.accept(self.user_token)
 
     def disconnect(self, close_code):
         async_to_sync(self.channel_layer.group_discard)(self.retro_id, self.channel_name)

--- a/backend/tests/api/consumers_test.py
+++ b/backend/tests/api/consumers_test.py
@@ -93,7 +93,7 @@ def test_connect(mock_accept_function, mock_async_to_sync_function, mock_service
     object_under_test.connect()
 
     mock_group_add.assert_called_once()
-    mock_accept_function.assert_called_once()
+    mock_accept_function.assert_called_with(object_under_test, mock_user_token)
 
 
 @patch('backend.api.consumers.async_to_sync', autospec=True)


### PR DESCRIPTION
Fixes #84.